### PR TITLE
Automate Container image release procedure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Image
         run: |
-          docker build --build-arg RHOAS_VERSION=$RHOAS_VERSION --rm -t quay.io/rhoas/tools .
-          docker tag quay.io/rhoas/tools:$RHOAS_VERSION quay.io/rhoas/tools:$RHOAS_VERSION
+          TAG=$RHOAS_VERSION ./build-docker-container.sh
         env:
+          REGISTRY_USERNAME: ${{ secrets.quayUsername }}
           RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
   push:
     depends-on: build-image
@@ -29,8 +29,9 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.quayPassword }}
       - id: Push to Quay.io
         run: |
-          docker push quay.io/rhoas/tools
-          docker push quay.io/rhoas/tools:$TAG
+          docker push quay.io/$QUAY_USERNAME/tools
+          docker push quay.io/$QUAY_USERNAME/tools:$TAG
         env:
+          QUAY_USERNAME: ${{ secrets.quayUsername }}
           TAG: ${{ github.event.inputs.rhoasVersion }}
         

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,11 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Image
-        run: |
-          TAG=$RHOAS_VERSION ./build-docker-container.sh
+        run: ./build-docker-container.sh
         env:
-          REGISTRY_USERNAME: ${{ secrets.quayUsername }}
-          RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
+          TAG: ${{ github.event.inputs.rhoasVersion }}
   push:
     depends-on: build-image
     runs-on: ubuntu-latest
@@ -29,9 +27,8 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.quayPassword }}
       - id: Push to Quay.io
         run: |
-          docker push quay.io/$QUAY_USERNAME/tools
-          docker push quay.io/$QUAY_USERNAME/tools:$TAG
+          docker push quay.io/rhoas/tools
+          docker push quay.io/rhoas/tools:$TAG
         env:
-          QUAY_USERNAME: ${{ secrets.quayUsername }}
           TAG: ${{ github.event.inputs.rhoasVersion }}
         

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Build Image
         run: ./build-docker-container.sh
         env:
-          TAG: ${{ github.event.inputs.rhoasVersion }}
+          RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
   push:
     depends-on: build-image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build and Push Container
+on:
+  workflow_dispatch:
+    inputs:
+      rhoasVersion:
+        description: 'Release version of the rhoas CLI'     
+        required: true
+        default: 'error' 
+        type: string
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Image
+        run: |
+          docker build --build-arg RHOAS_VERSION=$RHOAS_VERSION --rm -t quay.io/rhoas/tools .
+          docker tag quay.io/rhoas/tools:$RHOAS_VERSION quay.io/rhoas/tools:$RHOAS_VERSION
+        env:
+          RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
+  push:
+    depends-on: build-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Quay.io
+        run: docker login quay.io --username $QUAY_USERNAME --password $QUAY_PASSWORD
+        env:
+          QUAY_USERNAME: ${{ secrets.quayUsername }}
+          QUAY_PASSWORD: ${{ secrets.quayPassword }}
+      - id: Push to Quay.io
+        run: |
+          docker push quay.io/rhoas/tools
+          docker push quay.io/rhoas/tools:$TAG
+        env:
+          TAG: ${{ github.event.inputs.rhoasVersion }}
+        

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,7 @@ jobs:
           QUAY_USERNAME: ${{ secrets.quayUsername }}
           QUAY_PASSWORD: ${{ secrets.quayPassword }}
       - id: Push to Quay.io
-        run: |
-          docker push quay.io/rhoas/tools
-          docker push quay.io/rhoas/tools:$TAG
+        run: ./push-to-registry.sh
         env:
-          TAG: ${{ github.event.inputs.rhoasVersion }}
+          RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
         

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN yum update -y && yum install \
 
 COPY ./install-rhoas.sh .
 
-ENV TAG=v0.39.0
-RUN RHOAS_CLI_PATH=/opt/rhoas ./install-rhoas.sh
+ARG RHOAS_VERSION
+RUN RHOAS_CLI_PATH=/opt/rhoas TAG=$RHOAS_VERSION ./install-rhoas.sh
 
 #Using version 1.6 of Kafkacat. Build from master has an issue where it doesn't accept input in producer mode until you hit Ctrl-D.
 RUN git clone --depth 1 --branch 1.6.0 https://github.com/edenhill/kafkacat /opt/kafkacat    

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ USER rhoas
 COPY contrib/oc /usr/local/bin/oc
 COPY contrib/odo /usr/local/bin/odo
 COPY --from=builder --chown=root:root /opt/rhoas ${RHOAS_CLI_PATH}
+COPY scripts /usr/local/bin
 
 USER root
 RUN mkdir -p /.config/rhoas && chmod 777 -R /.config/rhoas && echo "{}" > /.config/rhoas/config.json && chmod 777 /.config/rhoas/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV RHOAS_CLI_PATH="/usr/local/bin/rhoas"
 ENV OC_CLI_PATH="/usr/local/bin/oc"
 
 # Install required packages
-RUN microdnf install shadow-utils yum
+RUN microdnf install shadow-utils yum jq
 
 # Create the RHOAS user
 RUN useradd -ms /bin/bash rhoas

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Tools docker image that contain number of CLIs that can be executed as container
 
 ## Running image
 
-```
-docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash quay.io/rhosak/rhoas-tools
+```shell
+docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash quay.io/rhoas/tools
 ```
 
 ## Support scripts

--- a/build-docker-container.sh
+++ b/build-docker-container.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-rhoas_version=$TAG
+rhoas_version=$RHOAS_VERSION
 image_tag=${rhoas_version/#"v"}
 
 registry=${REGISTRY:-quay.io}

--- a/build-docker-container.sh
+++ b/build-docker-container.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-docker build --rm -t ddoyle/rhoas-devsandbox-workshop-tools .
+set -uo pipefail
+
+registry=${REGISTRY:-quay.io}
+username=${USERNAME}
+
+docker build --build-arg RHOAS_VERSION=$TAG --rm -t $registry/$username/tools .
+docker tag $registry/$username/tools $registry/$username:$TAG

--- a/build-docker-container.sh
+++ b/build-docker-container.sh
@@ -3,7 +3,7 @@
 set -uo pipefail
 
 registry=${REGISTRY:-quay.io}
-username=${USERNAME}
+username=${REGISTRY_USERNAME:-rhoas}
 
 docker build --build-arg RHOAS_VERSION=$TAG --rm -t $registry/$username/tools .
 docker tag $registry/$username/tools $registry/$username:$TAG

--- a/build-docker-container.sh
+++ b/build-docker-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# set -uo pipefail
+set -uo pipefail
 
 rhoas_version=$TAG
 image_tag=${rhoas_version/#"v"}

--- a/build-docker-container.sh
+++ b/build-docker-container.sh
@@ -1,9 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
-set -uo pipefail
+# set -uo pipefail
+
+rhoas_version=$TAG
+image_tag=${rhoas_version/#"v"}
 
 registry=${REGISTRY:-quay.io}
-username=${REGISTRY_USERNAME:-rhoas}
+registry_org=${REGISTRY_ORG:-rhoas}
 
-docker build --build-arg RHOAS_VERSION=$TAG --rm -t $registry/$username/tools .
-docker tag $registry/$username/tools $registry/$username:$TAG
+image_name=$registry/$registry_org/tools
+
+docker build --build-arg RHOAS_VERSION=$rhoas_version --rm -t $image_name .
+docker tag $image_name $image_name:$image_tag

--- a/install-rhoas.sh
+++ b/install-rhoas.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -uo pipefail
 

--- a/install-rhoas.sh
+++ b/install-rhoas.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -uo pipefail
+
+tag=${TAG:-100}
+release_name=${tag/#"v"}
+os="${OS:-linux}" # linux, macOS
+arch="${ARCH:-amd64}" # amd64, arm64
+asset_name=rhoas_${release_name}_${os}_${arch}
+tarball_name=${asset_name}.tar.gz
+org_name="redhat-developer"
+repo_name="app-services-cli"
+binary_name="rhoas"
+binary_path=${RHOAS_CLI_PATH:-/usr/local/bin/rhoas}
+tmp_dir="/tmp/${binary_name}-${tag}-$(date +%s)"
+
+mkdir -p $tmp_dir && cd $tmp_dir
+
+wget https://github.com/${org_name}/${repo_name}/releases/download/${tag}/$tarball_name
+tar -xvzf $tarball_name
+
+mv $tmp_dir/${asset_name}/${binary_name} $binary_path

--- a/install-rhoas.sh
+++ b/install-rhoas.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-tag=${TAG:-100}
+tag=${TAG}
 release_name=${tag/#"v"}
 os="${OS:-linux}" # linux, macOS
 arch="${ARCH:-amd64}" # amd64, arm64

--- a/push-to-registry.sh
+++ b/push-to-registry.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 set -uo pipefail
 
+tag=${TAG/#"v"} # remove "v" prefix
 registry=${REGISTRY:-quay.io}
-username=${USERNAME}
+registry_org=${REGISTRY_ORG:-rhoas}
 password=${PASSWORD}
 
-docker login ${registry} --username $USERNAME --password $PASSWORD
+image_name=$registry/$registry_org/tools
 
-docker push $registry/$username/tools
+# docker push $image_name
+# docker push $image_name:$tag

--- a/push-to-registry.sh
+++ b/push-to-registry.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -uo pipefail
+
+registry=${REGISTRY:-quay.io}
+username=${USERNAME}
+password=${PASSWORD}
+
+docker login ${registry} --username $USERNAME --password $PASSWORD
+
+docker push $registry/$username/tools

--- a/push-to-registry.sh
+++ b/push-to-registry.sh
@@ -2,12 +2,11 @@
 
 set -uo pipefail
 
-tag=${TAG/#"v"} # remove "v" prefix
+tag=${RHOAS_VERSION/#"v"} # remove "v" prefix
 registry=${REGISTRY:-quay.io}
 registry_org=${REGISTRY_ORG:-rhoas}
-password=${PASSWORD}
 
 image_name=$registry/$registry_org/tools
 
-# docker push $image_name
-# docker push $image_name:$tag
+docker push $image_name:latest
+docker push $image_name:$tag

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash ddoyle/rhoas-devsandbox-workshop-tools
+docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash quay.io/rhoas/tools

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 registry=${REGISTRY:-quay.io}
 username=${USERNAME}

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-registry=${REGISTRY:-quay.io}
-username=${USERNAME}
-
-docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash $registry/$username/tools

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash quay.io/rhoas/tools
+registry=${REGISTRY:-quay.io}
+username=${USERNAME}
+
+docker run -ti --rm --name rhoas-devsandbox --entrypoint /bin/bash $registry/$username/tools

--- a/tag-image-for-quay.sh
+++ b/tag-image-for-quay.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-docker tag ddoyle/rhoas-devsandbox-workshop-tools quay.io/rhosak/rhoas-tools


### PR DESCRIPTION
## Description

The primary outcome of this pull request is for the `quay.io/rhoas/tools` to be built and published automatically.

Secondary outcomes:

* Change image from `quay.io/rhosak/rhoas-tools`
* Add/improve scripts to enable the continuation of manual process when needed

## Verification

The automation cannot be verified until this has been merged, and we are also waiting for the image namespace to be created on Quay.

**Verification with scripts**

1. Run `./build-docker-container.sh` to build the image
2. Run `./push-to-registry.sh` to push the image to Quay/Docker (requires username/password)





