### PR TITLE
fix: use a single job to build and push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,10 @@ on:
       rhoasVersion:
         description: 'Release version of the rhoas CLI'     
         required: true
-        default: 'error' 
+        default: '' 
         type: string
 jobs:
-  build-image:
+  docker-build-push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,10 +16,6 @@ jobs:
         run: ./build-docker-container.sh
         env:
           RHOAS_VERSION: ${{ github.event.inputs.rhoasVersion }}
-  push:
-    needs: build-image
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v2
       - name: Login to Quay.io
         run: docker login quay.io --username $QUAY_USERNAME --password $QUAY_PASSWORD


### PR DESCRIPTION
The current builds are failing because the image cannot be found when pushing to Quay. This is because data is not shared between jobs.
This merges all steps into a single job.
